### PR TITLE
feat: settlement recording with balance integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,10 +2776,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seahash"
@@ -2875,6 +2890,32 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3086,6 +3127,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
+ "serial_test",
  "sqlx",
  "tokio",
 ]

--- a/crates/splitvibe-core/src/balance.rs
+++ b/crates/splitvibe-core/src/balance.rs
@@ -18,20 +18,39 @@ pub struct ExpenseEntry {
     pub splits: Vec<(String, Decimal)>,
 }
 
-/// Calculate simplified debts from a list of expense entries.
+/// A settlement entry: payer paid payee to settle a debt.
+#[derive(Debug, Clone)]
+pub struct SettlementEntry {
+    /// User ID of who made the payment.
+    pub payer: String,
+    /// User ID of who received the payment.
+    pub payee: String,
+    /// Amount paid.
+    pub amount: Decimal,
+}
+
+/// Calculate simplified debts from expenses and settlements.
 ///
 /// Uses a greedy min-cash-flow algorithm:
-/// 1. Compute each person's net balance (paid - owed).
-/// 2. Repeatedly match the person who owes the most with the person owed the most.
-/// 3. Transfer the minimum of the two and repeat until settled.
+/// 1. Compute each person's net balance (paid - owed) from expenses.
+/// 2. Apply settlements (payer→payee transfers reduce net balances).
+/// 3. Repeatedly match the person who owes the most with the person owed the most.
 ///
 /// Returns debts sorted by (from, to) for deterministic output.
 pub fn calculate_debts(entries: &[ExpenseEntry]) -> Vec<Debt> {
-    if entries.is_empty() {
+    calculate_debts_with_settlements(entries, &[])
+}
+
+/// Calculate debts accounting for both expenses and settlements.
+pub fn calculate_debts_with_settlements(
+    entries: &[ExpenseEntry],
+    settlements: &[SettlementEntry],
+) -> Vec<Debt> {
+    if entries.is_empty() && settlements.is_empty() {
         return Vec::new();
     }
 
-    // Step 1: compute net balances
+    // Step 1: compute net balances from expenses
     let mut balances: HashMap<String, Decimal> = HashMap::new();
 
     for entry in entries {
@@ -41,6 +60,12 @@ pub fn calculate_debts(entries: &[ExpenseEntry]) -> Vec<Debt> {
         for (user_id, amount) in &entry.splits {
             *balances.entry(user_id.clone()).or_default() -= amount;
         }
+    }
+
+    // Step 2: apply settlements (payer pays payee → payer's balance goes up, payee's goes down)
+    for s in settlements {
+        *balances.entry(s.payer.clone()).or_default() += s.amount;
+        *balances.entry(s.payee.clone()).or_default() -= s.amount;
     }
 
     // Step 2: greedy min-cash-flow
@@ -217,6 +242,91 @@ mod tests {
         ];
 
         let debts = calculate_debts(&entries);
+        assert!(debts.is_empty());
+    }
+
+    #[test]
+    fn test_settlement_clears_debt() {
+        // Alice pays $90 split 3 ways → Bob owes $30, Charlie owes $30
+        // Bob settles $30 with Alice → Bob no longer owes
+        let entries = vec![ExpenseEntry {
+            payer: "Alice".into(),
+            splits: vec![
+                ("Alice".into(), dec!(30.00)),
+                ("Bob".into(), dec!(30.00)),
+                ("Charlie".into(), dec!(30.00)),
+            ],
+        }];
+
+        let settlements = vec![SettlementEntry {
+            payer: "Bob".into(),
+            payee: "Alice".into(),
+            amount: dec!(30.00),
+        }];
+
+        let debts = calculate_debts_with_settlements(&entries, &settlements);
+        assert_eq!(debts.len(), 1);
+        assert_eq!(
+            debts[0],
+            Debt {
+                from: "Charlie".into(),
+                to: "Alice".into(),
+                amount: dec!(30.00),
+            }
+        );
+    }
+
+    #[test]
+    fn test_settlement_partial() {
+        // Alice pays $90 split 3 ways → Bob owes $30
+        // Bob settles $10 → Bob still owes $20
+        let entries = vec![ExpenseEntry {
+            payer: "Alice".into(),
+            splits: vec![
+                ("Alice".into(), dec!(30.00)),
+                ("Bob".into(), dec!(30.00)),
+                ("Charlie".into(), dec!(30.00)),
+            ],
+        }];
+
+        let settlements = vec![SettlementEntry {
+            payer: "Bob".into(),
+            payee: "Alice".into(),
+            amount: dec!(10.00),
+        }];
+
+        let debts = calculate_debts_with_settlements(&entries, &settlements);
+        let bob_to_alice = debts.iter().find(|d| d.from == "Bob" && d.to == "Alice");
+        assert_eq!(bob_to_alice.unwrap().amount, dec!(20.00));
+    }
+
+    #[test]
+    fn test_full_settlement_clears_all() {
+        // Alice pays $90 split 3 ways
+        // Both Bob and Charlie settle $30 each → all settled
+        let entries = vec![ExpenseEntry {
+            payer: "Alice".into(),
+            splits: vec![
+                ("Alice".into(), dec!(30.00)),
+                ("Bob".into(), dec!(30.00)),
+                ("Charlie".into(), dec!(30.00)),
+            ],
+        }];
+
+        let settlements = vec![
+            SettlementEntry {
+                payer: "Bob".into(),
+                payee: "Alice".into(),
+                amount: dec!(30.00),
+            },
+            SettlementEntry {
+                payer: "Charlie".into(),
+                payee: "Alice".into(),
+                amount: dec!(30.00),
+            },
+        ];
+
+        let debts = calculate_debts_with_settlements(&entries, &settlements);
         assert!(debts.is_empty());
     }
 }

--- a/crates/splitvibe-db/Cargo.toml
+++ b/crates/splitvibe-db/Cargo.toml
@@ -15,3 +15,4 @@ tokio = { version = "1", features = ["full"] }
 dotenvy = "0.15"
 rust_decimal_macros = "1"
 chrono = "0.4"
+serial_test = "3"

--- a/crates/splitvibe-db/migrations/20260312000002_settlement_deleted_at.sql
+++ b/crates/splitvibe-db/migrations/20260312000002_settlement_deleted_at.sql
@@ -1,0 +1,2 @@
+-- Add deleted_at timestamp to settlements for 24h undo window
+ALTER TABLE settlements ADD COLUMN deleted_at TIMESTAMPTZ;

--- a/crates/splitvibe-db/src/models.rs
+++ b/crates/splitvibe-db/src/models.rs
@@ -97,4 +97,5 @@ pub struct Settlement {
     pub currency: String,
     pub deleted: bool,
     pub created_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
 }

--- a/crates/splitvibe-db/src/queries.rs
+++ b/crates/splitvibe-db/src/queries.rs
@@ -273,3 +273,87 @@ pub async fn get_expense_data_for_balances(
 
     Ok((payers, splits))
 }
+
+/// Settlement with display names for the payer and payee.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, sqlx::FromRow)]
+pub struct SettlementInfo {
+    pub id: String,
+    pub payer_name: String,
+    pub payee_name: String,
+    pub payer_id: String,
+    pub payee_id: String,
+    pub amount: Decimal,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub can_delete: bool,
+}
+
+/// Create a settlement record.
+pub async fn create_settlement(
+    pool: &PgPool,
+    id: &str,
+    group_id: &str,
+    payer_id: &str,
+    payee_id: &str,
+    amount: Decimal,
+) -> Result<crate::models::Settlement, sqlx::Error> {
+    sqlx::query_as::<_, crate::models::Settlement>(
+        "INSERT INTO settlements (id, group_id, payer_id, payee_id, amount) VALUES ($1, $2, $3, $4, $5) RETURNING *",
+    )
+    .bind(id)
+    .bind(group_id)
+    .bind(payer_id)
+    .bind(payee_id)
+    .bind(amount)
+    .fetch_one(pool)
+    .await
+}
+
+/// List active settlements for a group with display names and delete eligibility.
+pub async fn list_settlements_for_group(
+    pool: &PgPool,
+    group_id: &str,
+) -> Result<Vec<SettlementInfo>, sqlx::Error> {
+    sqlx::query_as::<_, SettlementInfo>(
+        r#"SELECT s.id, u1.display_name AS payer_name, u2.display_name AS payee_name,
+                  s.payer_id, s.payee_id, s.amount, s.created_at,
+                  (s.created_at > now() - interval '24 hours') AS can_delete
+           FROM settlements s
+           JOIN users u1 ON s.payer_id = u1.id
+           JOIN users u2 ON s.payee_id = u2.id
+           WHERE s.group_id = $1 AND s.deleted = false
+           ORDER BY s.created_at DESC"#,
+    )
+    .bind(group_id)
+    .fetch_all(pool)
+    .await
+}
+
+/// Soft-delete a settlement (set deleted=true, deleted_at=now()).
+pub async fn delete_settlement(
+    pool: &PgPool,
+    settlement_id: &str,
+    group_id: &str,
+) -> Result<bool, sqlx::Error> {
+    let result = sqlx::query(
+        "UPDATE settlements SET deleted = true, deleted_at = now() WHERE id = $1 AND group_id = $2 AND deleted = false AND created_at > now() - interval '24 hours'",
+    )
+    .bind(settlement_id)
+    .bind(group_id)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// Fetch active settlements for balance calculation.
+pub async fn get_settlements_for_balances(
+    pool: &PgPool,
+    group_id: &str,
+) -> Result<Vec<(String, String, Decimal)>, sqlx::Error> {
+    let rows = sqlx::query_as::<_, (String, String, Decimal)>(
+        "SELECT payer_id, payee_id, amount FROM settlements WHERE group_id = $1 AND deleted = false",
+    )
+    .bind(group_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}

--- a/crates/splitvibe-db/tests/expense_tests.rs
+++ b/crates/splitvibe-db/tests/expense_tests.rs
@@ -1,4 +1,5 @@
 use rust_decimal_macros::dec;
+use serial_test::serial;
 use splitvibe_db::queries;
 use sqlx::PgPool;
 
@@ -59,6 +60,7 @@ async fn setup_group_with_members(pool: &PgPool) {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_create_expense_returns_expense() {
     let pool = setup_pool().await;
     setup_group_with_members(&pool).await;
@@ -90,6 +92,7 @@ async fn test_create_expense_returns_expense() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_list_expenses_for_group() {
     let pool = setup_pool().await;
     setup_group_with_members(&pool).await;
@@ -126,6 +129,7 @@ async fn test_list_expenses_for_group() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_list_expenses_excludes_deleted() {
     let pool = setup_pool().await;
     setup_group_with_members(&pool).await;
@@ -160,6 +164,7 @@ async fn test_list_expenses_excludes_deleted() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_get_expense_data_for_balances() {
     let pool = setup_pool().await;
     setup_group_with_members(&pool).await;
@@ -197,6 +202,7 @@ async fn test_get_expense_data_for_balances() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_get_expense_data_excludes_deleted() {
     let pool = setup_pool().await;
     setup_group_with_members(&pool).await;

--- a/crates/splitvibe-db/tests/group_tests.rs
+++ b/crates/splitvibe-db/tests/group_tests.rs
@@ -1,3 +1,4 @@
+use serial_test::serial;
 use splitvibe_db::queries;
 use sqlx::PgPool;
 
@@ -38,6 +39,7 @@ async fn insert_mock_user(pool: &PgPool, id: &str, name: &str) {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_create_group_returns_group_with_correct_fields() {
     let pool = setup_pool().await;
     insert_mock_user(&pool, "alice-001", "Alice").await;
@@ -62,6 +64,7 @@ async fn test_create_group_returns_group_with_correct_fields() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_create_group_adds_creator_as_member() {
     let pool = setup_pool().await;
     insert_mock_user(&pool, "alice-001", "Alice").await;
@@ -84,6 +87,7 @@ async fn test_create_group_adds_creator_as_member() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_list_groups_for_user_returns_groups_with_member_count() {
     let pool = setup_pool().await;
     insert_mock_user(&pool, "alice-001", "Alice").await;
@@ -113,6 +117,7 @@ async fn test_list_groups_for_user_returns_groups_with_member_count() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_get_group_by_invite_token() {
     let pool = setup_pool().await;
     insert_mock_user(&pool, "alice-001", "Alice").await;
@@ -142,6 +147,7 @@ async fn test_get_group_by_invite_token() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_add_group_member_prevents_duplicates() {
     let pool = setup_pool().await;
     insert_mock_user(&pool, "alice-001", "Alice").await;
@@ -165,6 +171,7 @@ async fn test_add_group_member_prevents_duplicates() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_get_group_members_returns_user_info() {
     let pool = setup_pool().await;
     insert_mock_user(&pool, "alice-001", "Alice").await;
@@ -187,6 +194,7 @@ async fn test_get_group_members_returns_user_info() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_list_groups_excludes_non_member_groups() {
     let pool = setup_pool().await;
     insert_mock_user(&pool, "alice-001", "Alice").await;

--- a/crates/splitvibe-db/tests/settlement_tests.rs
+++ b/crates/splitvibe-db/tests/settlement_tests.rs
@@ -1,0 +1,148 @@
+use rust_decimal_macros::dec;
+use serial_test::serial;
+use splitvibe_db::queries;
+use sqlx::PgPool;
+
+async fn setup_pool() -> PgPool {
+    dotenvy::dotenv().ok();
+    let database_url =
+        std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for integration tests");
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    splitvibe_db::run_migrations(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    sqlx::raw_sql(
+        "TRUNCATE group_members, expense_splits, expense_payers, expenses, settlements, groups, sessions, users CASCADE;",
+    )
+    .execute(&pool)
+    .await
+    .expect("Failed to truncate tables");
+
+    pool
+}
+
+async fn insert_mock_user(pool: &PgPool, id: &str, name: &str) {
+    sqlx::query(
+        "INSERT INTO users (id, provider, provider_id, display_name, avatar_url) VALUES ($1, 'mock', $1, $2, 'https://example.com/avatar.png')"
+    )
+    .bind(id)
+    .bind(name)
+    .execute(pool)
+    .await
+    .expect("Failed to insert mock user");
+}
+
+async fn setup_group_with_members(pool: &PgPool) {
+    insert_mock_user(pool, "alice-001", "Alice").await;
+    insert_mock_user(pool, "bob-002", "Bob").await;
+
+    queries::create_group(pool, "grp-1", "Trip", "alice-001", "tok-1", "mem-1")
+        .await
+        .unwrap();
+    queries::add_group_member(pool, "mem-2", "grp-1", "bob-002")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_create_settlement() {
+    let pool = setup_pool().await;
+    setup_group_with_members(&pool).await;
+
+    let settlement =
+        queries::create_settlement(&pool, "stl-1", "grp-1", "bob-002", "alice-001", dec!(30.00))
+            .await
+            .expect("Failed to create settlement");
+
+    assert_eq!(settlement.payer_id, "bob-002");
+    assert_eq!(settlement.payee_id, "alice-001");
+    assert_eq!(settlement.amount, dec!(30.00));
+    assert!(!settlement.deleted);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_list_settlements_for_group() {
+    let pool = setup_pool().await;
+    setup_group_with_members(&pool).await;
+
+    queries::create_settlement(&pool, "stl-1", "grp-1", "bob-002", "alice-001", dec!(30.00))
+        .await
+        .unwrap();
+
+    let settlements = queries::list_settlements_for_group(&pool, "grp-1")
+        .await
+        .expect("Failed to list settlements");
+
+    assert_eq!(settlements.len(), 1);
+    assert_eq!(settlements[0].payer_name, "Bob");
+    assert_eq!(settlements[0].payee_name, "Alice");
+    assert_eq!(settlements[0].amount, dec!(30.00));
+    assert!(settlements[0].can_delete);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_delete_settlement_within_24h() {
+    let pool = setup_pool().await;
+    setup_group_with_members(&pool).await;
+
+    queries::create_settlement(&pool, "stl-1", "grp-1", "bob-002", "alice-001", dec!(30.00))
+        .await
+        .unwrap();
+
+    let deleted = queries::delete_settlement(&pool, "stl-1", "grp-1")
+        .await
+        .expect("Failed to delete settlement");
+    assert!(deleted);
+
+    let settlements = queries::list_settlements_for_group(&pool, "grp-1")
+        .await
+        .unwrap();
+    assert_eq!(settlements.len(), 0);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_get_settlements_for_balances() {
+    let pool = setup_pool().await;
+    setup_group_with_members(&pool).await;
+
+    queries::create_settlement(&pool, "stl-1", "grp-1", "bob-002", "alice-001", dec!(30.00))
+        .await
+        .unwrap();
+
+    let rows = queries::get_settlements_for_balances(&pool, "grp-1")
+        .await
+        .expect("Failed to get settlements for balances");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, "bob-002");
+    assert_eq!(rows[0].1, "alice-001");
+    assert_eq!(rows[0].2, dec!(30.00));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_deleted_settlement_excluded_from_balances() {
+    let pool = setup_pool().await;
+    setup_group_with_members(&pool).await;
+
+    queries::create_settlement(&pool, "stl-1", "grp-1", "bob-002", "alice-001", dec!(30.00))
+        .await
+        .unwrap();
+
+    queries::delete_settlement(&pool, "stl-1", "grp-1")
+        .await
+        .unwrap();
+
+    let rows = queries::get_settlements_for_balances(&pool, "grp-1")
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 0);
+}

--- a/crates/splitvibe-server/src/groups/handlers.rs
+++ b/crates/splitvibe-server/src/groups/handlers.rs
@@ -287,6 +287,75 @@ pub async fn groups_detail(
         format!(r#"<div class="expense-list">{}</div>"#, items.join("\n"))
     };
 
+    // Fetch settlements for display
+    let settlements_list =
+        match splitvibe_db::queries::list_settlements_for_group(pool.get_ref(), &group_id).await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!("Failed to list settlements: {}", e);
+                Vec::new()
+            }
+        };
+
+    let settlements_html = if settlements_list.is_empty() {
+        String::new()
+    } else {
+        let items: Vec<String> = settlements_list
+            .iter()
+            .map(|s| {
+                let delete_btn = if s.can_delete {
+                    format!(
+                        r#"<form method="post" action="/groups/{}/settlements/{}/delete" style="display:inline">
+                            <button type="submit" class="btn-delete">Delete</button>
+                        </form>"#,
+                        html_escape(&group_id),
+                        html_escape(&s.id),
+                    )
+                } else {
+                    String::new()
+                };
+                format!(
+                    r#"<div class="settlement-item">
+                        <div class="settlement-info">
+                            <span class="settlement-desc">{payer} paid {payee}</span>
+                            <span class="expense-meta">{date}</span>
+                        </div>
+                        <span class="settlement-amount">${amount}</span>
+                        {delete_btn}
+                    </div>"#,
+                    payer = html_escape(&s.payer_name),
+                    payee = html_escape(&s.payee_name),
+                    amount = s.amount.round_dp(2),
+                    date = s.created_at.format("%Y-%m-%d"),
+                )
+            })
+            .collect();
+        format!(r#"<div class="settlement-list">{}</div>"#, items.join("\n"))
+    };
+
+    // Fetch settlement data for balance calculation
+    let settlement_entries = match splitvibe_db::queries::get_settlements_for_balances(
+        pool.get_ref(),
+        &group_id,
+    )
+    .await
+    {
+        Ok(rows) => rows
+            .into_iter()
+            .map(
+                |(payer, payee, amount)| splitvibe_core::balance::SettlementEntry {
+                    payer,
+                    payee,
+                    amount,
+                },
+            )
+            .collect::<Vec<_>>(),
+        Err(e) => {
+            tracing::error!("Failed to get settlements for balances: {}", e);
+            Vec::new()
+        }
+    };
+
     // Fetch balance data and calculate debts
     let balances_html =
         match splitvibe_db::queries::get_expense_data_for_balances(pool.get_ref(), &group_id).await
@@ -313,7 +382,10 @@ pub async fn groups_detail(
 
                 let entries: Vec<splitvibe_core::balance::ExpenseEntry> =
                     expense_map.into_values().collect();
-                let debts = splitvibe_core::balance::calculate_debts(&entries);
+                let debts = splitvibe_core::balance::calculate_debts_with_settlements(
+                    &entries,
+                    &settlement_entries,
+                );
 
                 if debts.is_empty() {
                     r#"<p class="empty-state">All settled up!</p>"#.to_string()
@@ -368,6 +440,11 @@ pub async fn groups_detail(
             {expenses}
             <h2>Balances</h2>
             {balances}
+            <div class="group-actions">
+                <a href="/groups/{group_id}/settlements/new" class="btn btn-primary">Record Settlement</a>
+            </div>
+            <h2>Settlements</h2>
+            {settlements}
             <h2>Members ({count})</h2>
             <div class="member-list">
                 {members}
@@ -379,6 +456,11 @@ pub async fn groups_detail(
         invite_url = invite_url,
         expenses = expenses_html,
         balances = balances_html,
+        settlements = if settlements_html.is_empty() {
+            r#"<p class="empty-state">No settlements yet.</p>"#.to_string()
+        } else {
+            settlements_html
+        },
         count = members.len(),
         members = members_html.join("\n"),
     );
@@ -740,6 +822,203 @@ pub async fn expenses_create(
             .finish(),
         Err(e) => {
             tracing::error!("Failed to create expense: {}", e);
+            HttpResponse::InternalServerError().body("Database error")
+        }
+    }
+}
+
+/// GET /groups/{id}/settlements/new — show the record settlement form.
+pub async fn settlements_new(
+    session: Session,
+    pool: web::Data<sqlx::PgPool>,
+    path: web::Path<String>,
+) -> HttpResponse {
+    let user = match require_auth(&session) {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let group_id = path.into_inner();
+
+    let group = match splitvibe_db::queries::get_group_by_id(pool.get_ref(), &group_id).await {
+        Ok(Some(g)) => g,
+        Ok(None) => return HttpResponse::NotFound().body("Group not found"),
+        Err(e) => {
+            tracing::error!("Failed to get group: {}", e);
+            return HttpResponse::InternalServerError().body("Database error");
+        }
+    };
+
+    let members = match splitvibe_db::queries::get_group_members(pool.get_ref(), &group_id).await {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::error!("Failed to get group members: {}", e);
+            return HttpResponse::InternalServerError().body("Database error");
+        }
+    };
+
+    let content = settlement_form_html(&group.id, &group.name, &members, None);
+    let navbar = navbar_html(&user);
+    HttpResponse::Ok()
+        .content_type("text/html; charset=utf-8")
+        .body(page_html("Record Settlement", &navbar, &content))
+}
+
+fn settlement_form_html(
+    group_id: &str,
+    group_name: &str,
+    members: &[splitvibe_db::queries::GroupMemberInfo],
+    error: Option<&str>,
+) -> String {
+    let payer_options: Vec<String> = members
+        .iter()
+        .map(|m| {
+            format!(
+                r#"<option value="{id}">{name}</option>"#,
+                id = html_escape(&m.user_id),
+                name = html_escape(&m.display_name),
+            )
+        })
+        .collect();
+
+    let payee_options = payer_options.clone();
+
+    let error_html = error
+        .map(|msg| format!(r#"<div class="error-message">{}</div>"#, html_escape(msg)))
+        .unwrap_or_default();
+
+    format!(
+        r#"<h1>Record Settlement in {group_name}</h1>
+        {error_html}
+        <form method="post" action="/groups/{group_id}/settlements" class="form">
+            <div class="form-group">
+                <label for="payer_id">Who paid</label>
+                <select id="payer_id" name="payer_id" class="form-input">
+                    {payer_options}
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="payee_id">Who received</label>
+                <select id="payee_id" name="payee_id" class="form-input">
+                    {payee_options}
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="amount">Amount ($)</label>
+                <input type="number" id="amount" name="amount" required step="0.01" min="0.01" placeholder="0.00" class="form-input"/>
+            </div>
+            <button type="submit" class="btn btn-primary">Record Settlement</button>
+            <a href="/groups/{group_id}" class="btn btn-secondary">Cancel</a>
+        </form>"#,
+        group_name = html_escape(group_name),
+        group_id = html_escape(group_id),
+        payer_options = payer_options.join("\n"),
+        payee_options = payee_options.join("\n"),
+    )
+}
+
+#[derive(serde::Deserialize)]
+pub struct CreateSettlementForm {
+    pub payer_id: String,
+    pub payee_id: String,
+    pub amount: String,
+}
+
+/// POST /groups/{id}/settlements — create a settlement.
+pub async fn settlements_create(
+    session: Session,
+    pool: web::Data<sqlx::PgPool>,
+    path: web::Path<String>,
+    form: web::Form<CreateSettlementForm>,
+) -> HttpResponse {
+    let user = match require_auth(&session) {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let group_id = path.into_inner();
+
+    let group = match splitvibe_db::queries::get_group_by_id(pool.get_ref(), &group_id).await {
+        Ok(Some(g)) => g,
+        Ok(None) => return HttpResponse::NotFound().body("Group not found"),
+        Err(e) => {
+            tracing::error!("Failed to get group: {}", e);
+            return HttpResponse::InternalServerError().body("Database error");
+        }
+    };
+
+    let members = match splitvibe_db::queries::get_group_members(pool.get_ref(), &group_id).await {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::error!("Failed to get group members: {}", e);
+            return HttpResponse::InternalServerError().body("Database error");
+        }
+    };
+
+    let show_error = |msg: &str| {
+        let content = settlement_form_html(&group.id, &group.name, &members, Some(msg));
+        let navbar = navbar_html(&user);
+        HttpResponse::Ok()
+            .content_type("text/html; charset=utf-8")
+            .body(page_html("Record Settlement", &navbar, &content))
+    };
+
+    // Validate amount
+    let amount = match form.amount.trim().parse::<rust_decimal::Decimal>() {
+        Ok(a) if a > rust_decimal::Decimal::ZERO => a,
+        _ => return show_error("Amount must be a positive number."),
+    };
+
+    // Validate payer != payee
+    if form.payer_id == form.payee_id {
+        return show_error("Payer and payee must be different people.");
+    }
+
+    let settlement_id = cuid2::create_id();
+
+    match splitvibe_db::queries::create_settlement(
+        pool.get_ref(),
+        &settlement_id,
+        &group.id,
+        &form.payer_id,
+        &form.payee_id,
+        amount,
+    )
+    .await
+    {
+        Ok(_) => HttpResponse::SeeOther()
+            .insert_header(("Location", format!("/groups/{}", group.id)))
+            .finish(),
+        Err(e) => {
+            tracing::error!("Failed to create settlement: {}", e);
+            HttpResponse::InternalServerError().body("Database error")
+        }
+    }
+}
+
+/// POST /groups/{group_id}/settlements/{settlement_id}/delete — soft-delete a settlement.
+pub async fn settlements_delete(
+    session: Session,
+    pool: web::Data<sqlx::PgPool>,
+    path: web::Path<(String, String)>,
+) -> HttpResponse {
+    let _user = match require_auth(&session) {
+        Ok(u) => u,
+        Err(r) => return r,
+    };
+
+    let (group_id, settlement_id) = path.into_inner();
+
+    match splitvibe_db::queries::delete_settlement(pool.get_ref(), &settlement_id, &group_id).await
+    {
+        Ok(true) => HttpResponse::SeeOther()
+            .insert_header(("Location", format!("/groups/{}", group_id)))
+            .finish(),
+        Ok(false) => HttpResponse::SeeOther()
+            .insert_header(("Location", format!("/groups/{}", group_id)))
+            .finish(),
+        Err(e) => {
+            tracing::error!("Failed to delete settlement: {}", e);
             HttpResponse::InternalServerError().body("Database error")
         }
     }

--- a/crates/splitvibe-server/src/groups/handlers.rs
+++ b/crates/splitvibe-server/src/groups/handlers.rs
@@ -907,6 +907,10 @@ fn settlement_form_html(
                 <label for="amount">Amount ($)</label>
                 <input type="number" id="amount" name="amount" required step="0.01" min="0.01" placeholder="0.00" class="form-input"/>
             </div>
+            <div class="form-group">
+                <label for="date">Date</label>
+                <input type="date" id="date" name="date" class="form-input" value="{today}"/>
+            </div>
             <button type="submit" class="btn btn-primary">Record Settlement</button>
             <a href="/groups/{group_id}" class="btn btn-secondary">Cancel</a>
         </form>"#,
@@ -914,6 +918,7 @@ fn settlement_form_html(
         group_id = html_escape(group_id),
         payer_options = payer_options.join("\n"),
         payee_options = payee_options.join("\n"),
+        today = chrono::Local::now().format("%Y-%m-%d"),
     )
 }
 

--- a/crates/splitvibe-server/src/main.rs
+++ b/crates/splitvibe-server/src/main.rs
@@ -85,6 +85,19 @@ async fn main() -> std::io::Result<()> {
                 "/groups/{id}/expenses",
                 web::post().to(groups::handlers::expenses_create),
             )
+            // Settlement routes
+            .route(
+                "/groups/{id}/settlements/new",
+                web::get().to(groups::handlers::settlements_new),
+            )
+            .route(
+                "/groups/{id}/settlements",
+                web::post().to(groups::handlers::settlements_create),
+            )
+            .route(
+                "/groups/{group_id}/settlements/{settlement_id}/delete",
+                web::post().to(groups::handlers::settlements_delete),
+            )
             // Leptos routes
             .leptos_routes(routes.clone(), {
                 let options = leptos_options.clone();

--- a/crates/splitvibe-server/style/main.css
+++ b/crates/splitvibe-server/style/main.css
@@ -334,3 +334,50 @@ select.form-input {
     font-weight: 600;
     color: #e53e3e;
 }
+
+.settlement-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin: 1rem 0;
+}
+
+.settlement-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    background: white;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.375rem;
+}
+
+.settlement-info {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+}
+
+.settlement-desc {
+    font-weight: 600;
+}
+
+.settlement-amount {
+    font-weight: 600;
+    color: #38a169;
+    margin-right: 0.5rem;
+}
+
+.btn-delete {
+    background: none;
+    border: 1px solid #e53e3e;
+    color: #e53e3e;
+    border-radius: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    cursor: pointer;
+    font-size: 0.8rem;
+}
+
+.btn-delete:hover {
+    background: #fed7d7;
+}


### PR DESCRIPTION
## Summary

- Add settlement recording flow: form, create, soft-delete with 24h undo window
- Update balance algorithm to account for settlements (`calculate_debts_with_settlements`)
- Display settlements on group detail page with delete buttons (within 24h)
- Validate settlement amounts (positive, payer != payee)
- DB migration adding `deleted_at` column to settlements table
- 5 new settlement DB integration tests, 3 new balance unit tests
- Fix DB test race conditions with `serial_test` crate

Closes #7

## Test plan

- [ ] Settlement form shows payer, payee, and amount fields
- [ ] Creating a settlement updates balances correctly
- [ ] Delete button visible for settlements < 24h old
- [ ] Deleting a settlement reverts balances
- [ ] No delete button for settlements > 24h old
- [ ] Cross-story: expense + settlement balance calculation correct
- [ ] Zero JS console errors
- [ ] Validation error for zero/negative amounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)